### PR TITLE
Switch to gopkg.in to avoid name issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.DS_Store
+/gocbeventer

--- a/eventer/eventingmanager.go
+++ b/eventer/eventingmanager.go
@@ -1,12 +1,13 @@
 package eventer
 
 import (
-	"time"
-	"github.com/couchbase/gocb"
-	"github.com/google/uuid"
-	"github.com/brett19/gocbdistapp"
-	"fmt"
 	"errors"
+	"fmt"
+	"time"
+
+	"github.com/brett19/gocbdistapp"
+	"github.com/google/uuid"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 var (

--- a/eventer/init.go
+++ b/eventer/init.go
@@ -1,10 +1,11 @@
 package eventer
 
 import (
-	"github.com/couchbase/gocb"
-	"time"
 	"fmt"
 	"io/ioutil"
+	"time"
+
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 func Start() {

--- a/eventer/watcher.go
+++ b/eventer/watcher.go
@@ -1,12 +1,13 @@
 package eventer
 
 import (
-	"time"
-	"github.com/couchbase/gocb"
-	"regexp"
 	"fmt"
-	"github.com/couchbase/gocbcore"
+	"regexp"
+	"time"
+
 	sdcp "github.com/brett19/gosimpledcp"
+	"gopkg.in/couchbase/gocb.v1"
+	"gopkg.in/couchbase/gocbcore.v2"
 )
 
 type WatcherConfig struct {

--- a/eventer/watcherctrlr.go
+++ b/eventer/watcherctrlr.go
@@ -1,6 +1,6 @@
 package eventer
 
-import "github.com/couchbase/gocb"
+import "gopkg.in/couchbase/gocb.v1"
 
 type WatcherCtrlr struct {
 	cntlBucket *gocb.Bucket


### PR DESCRIPTION
In particular error checking[1] is broken if any of the build objects uses
github.com/couchbase/cbcore import path. The API exposes aliases to points
for error names, and those pointers are not actual constant literals
and might vary in different builds (if not static build, it would be kind
of ABI breakage every library build).

[1]: https://github.com/brett19/gocbeventer/blob/05f5ad3d9bd06cb8ae4398dd6e49a91073b14a4f/eventer/watcher.go#L69